### PR TITLE
Add tip about jsx options

### DIFF
--- a/packages/@vue/babel-preset-app/README.md
+++ b/packages/@vue/babel-preset-app/README.md
@@ -89,6 +89,7 @@ Use this option when you have 3rd party dependencies that are not processed by B
 - Default: `true`.
 
 Set to `false` to disable JSX support.
+Or you can toggle [@vue/babel-preset-jsx](https://github.com/vuejs/jsx/tree/dev/packages/babel-preset-jsx) features here
 
 ### loose
 


### PR DESCRIPTION
missing document when i want to disabled @vue/babel-preset-jsx injectH feature